### PR TITLE
Use HTML.fragment instead of HTML.parse

### DIFF
--- a/lib/jekyll-extlinks.rb
+++ b/lib/jekyll-extlinks.rb
@@ -48,7 +48,7 @@ module Jekyll
       # Stop if no attributes were specified
       return content unless attributes
 
-      doc = Nokogiri::HTML.parse(content)
+      doc = Nokogiri::HTML.fragment(content)
       # Stop if we could't parse with HTML
       return content unless doc
 


### PR DESCRIPTION
`HTML.parse` will include doctype, `<html>` and `<body>` tags when using `to_s`.
Using `HTML.fragment` avoids this.