### PR TITLE
Preserve existing class attribute values

### DIFF
--- a/lib/jekyll-extlinks.rb
+++ b/lib/jekyll-extlinks.rb
@@ -62,7 +62,11 @@ module Jekyll
             next unless !a.get_attribute('rel') || a.get_attribute('rel').empty?
             # Skip whitelisted hosts for the 'rel' attribute
             next if rel_exclude && contains_any(a.get_attribute('href'), rel_exclude)
+          elsif attr.downcase == 'class'
+            # Preserve any class attribute values that are already set
+            value = "#{a.get_attribute(attr)} #{value}" if a.get_attribute(attr)
           end
+
           a.set_attribute(attr, value)
         end
       end


### PR DESCRIPTION
Hi, this change appends to the class attribute rather than replacing it.

For my use case, I have different styling applied to my external links depending on the context in which they are used. I want `jekyll-extlinks` to add the class name `extlink` to the class attribute without overwriting any class names that are already in place.

Thanks for the indispensable plugin!