### PR TITLE
Bump nokogiri and jekyll versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,77 @@
+PATH
+  remote: .
+  specs:
+    jekyll-extlinks (0.0.5)
+      jekyll (~> 4.0)
+      nokogiri (~> 1.10.4)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    colorator (1.1.0)
+    concurrent-ruby (1.1.5)
+    em-websocket (0.5.1)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
+    eventmachine (1.2.7)
+    ffi (1.11.1)
+    forwardable-extended (2.6.0)
+    http_parser.rb (0.6.0)
+    i18n (1.6.0)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.0.0)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (>= 0.9.5, < 2)
+      jekyll-sass-converter (~> 2.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 2.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (~> 3.0)
+      safe_yaml (~> 1.0)
+      terminal-table (~> 1.8)
+    jekyll-sass-converter (2.0.1)
+      sassc (> 2.0.1, < 3.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    kramdown (2.1.0)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.3)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
+    mercenary (0.3.6)
+    mini_portile2 (2.4.0)
+    nokogiri (1.10.4)
+      mini_portile2 (~> 2.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (4.0.1)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
+    rouge (3.11.0)
+    ruby_dep (1.5.0)
+    safe_yaml (1.0.5)
+    sassc (2.2.1)
+      ffi (~> 1.9)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
+    unicode-display_width (1.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll-extlinks!
+
+BUNDLED WITH
+   1.17.2

--- a/jekyll-extlinks.gemspec
+++ b/jekyll-extlinks.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = "jekyll-extlinks"
-  s.version     = "0.0.4"
-  s.date        = "2017-06-08"
+  s.version     = "0.0.5"
+  s.date        = "2019-09-29"
   s.summary     = "Jekyll ExtLinks Plugin"
   s.description = <<-EOF
     Adds custom attributes to external links (rel="nofollow", target="_blank", etc.)
@@ -12,6 +12,6 @@ Gem::Specification.new do |s|
   s.homepage    = "http://ogarkov.com/jekyll/plugins/extlinks/"
   s.license     = "MIT"
 
-  s.add_runtime_dependency "jekyll", "~> 3.0" 
-  s.add_runtime_dependency "nokogiri", "~> 1.6" 
+  s.add_runtime_dependency "jekyll", "~> 4.0"
+  s.add_runtime_dependency "nokogiri", "~> 1.10.4"
 end


### PR DESCRIPTION
There is a [CVE for Nokogiri](https://nvd.nist.gov/vuln/detail/CVE-2019-5477) so this bumps the version to resolve the security issues
